### PR TITLE
Restrict OTP Sending to Valid Emails Only (#23)

### DIFF
--- a/src/Pages/login_signupPage/SignupForm.jsx
+++ b/src/Pages/login_signupPage/SignupForm.jsx
@@ -50,6 +50,7 @@ export default () => {
   const [otpSent, setOtpSent] = useState(false);
   const [otpVerified, setOtpVerified] = useState(false);
   const navigate = useNavigate();
+  const [isEmailValid, setIsEmailValid] = useState(false);
 
   const onFinish = async (values) => {
     console.log("Received values of form: ", values);
@@ -136,7 +137,8 @@ export default () => {
 
   const handleEmailChange = (e) => {
     const email = e.target.value;
-    if (email.endsWith("@sst.scaler.com")) {
+    if (email.endsWith("@sst.scaler.com") || email.endsWith("@scaler.com")) {
+      setIsEmailValid(true);
       setIsStudent(true);
     } else {
       setIsStudent(false);
@@ -192,7 +194,10 @@ export default () => {
 
       {!otpVerified && (
         <Form.Item {...tailFormItemLayout}>
-          <Button type="primary" onClick={handleGetOtpClick}>
+          <Button type="primary" 
+          onClick={handleGetOtpClick}
+          disabled ={!isEmailValid}
+          >
             {otpSent ? "Resend OTP" : "Send OTP"}
           </Button>
         </Form.Item>


### PR DESCRIPTION
#23
This PR addresses an issue where users could request OTP for invalid email addresses (emails not ending with @sst.scaler.com or @scaler.com). The following changes have been implemented:
    Introduced validation logic to ensure that the "Send OTP" button is enabled only when the entered email matches the required domains.
    Updated the handleEmailChange function to validate the email and set the button's state accordingly.
    Prevented OTP requests for invalid emails by disabling the button or hiding it when the email is invalid.
    
![Screenshot from 2024-12-30 21-43-50](https://github.com/user-attachments/assets/95e732c3-90a7-4e3a-acfd-bf1d19aba633)
![Screenshot from 2024-12-30 21-44-49](https://github.com/user-attachments/assets/1e8ca5a6-b8b6-4460-b388-53d03095350a)
